### PR TITLE
Avoid error when tracking number is not found

### DIFF
--- a/lib/amazon/order_importer.rb
+++ b/lib/amazon/order_importer.rb
@@ -28,9 +28,13 @@ module Amazon
 
       def shipment_from_tracking_page(shipment_id, tracking_page)
         shipment = Amazon::Shipment.find_or_initialize_by(shipment_id: shipment_id)
-        tracking_number_string   = tracking_page.search(@@css_paths['tracking_number']).first.content
-        carrier, tracking_number = tracking_number_string.split(',').map { |str| str.split(':').last }.map(&:strip)
-        shipment.update_attributes carrier: carrier, tracking_number: tracking_number
+        tracking_number_string = tracking_page.search(@@css_paths['tracking_number']).first.content rescue nil
+
+        if tracking_number_string
+          carrier, tracking_number = tracking_number_string.split(',').map { |str| str.split(':').last }.map(&:strip)
+          shipment.update_attributes carrier: carrier, tracking_number: tracking_number
+        end
+
         shipment
       end
 


### PR DESCRIPTION
Just tried this, and had error:

```
rake aborted!
NoMethodError: undefined method `content' for nil:NilClass
/Users/max/dev/amazon-orders/lib/amazon/order_importer.rb:31:in `shipment_from_tracking_page'
/Users/max/dev/amazon-orders/lib/amazon/order_importer.rb:68:in `block (2 levels) in parse_shipments_for_order'
/Users/max/dev/amazon-orders/lib/amazon/order_importer.rb:60:in `block in parse_shipments_for_order'
/Users/max/dev/amazon-orders/lib/amazon/order_importer.rb:53:in `each_with_index'
```

This quick fix made it work.